### PR TITLE
:sparkles: Add functionality to delete existing artifact comments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,21 @@ async function main(): Promise<void> {
 
     const body = `:package: **Build Artifacts**\n\n${artifactLinks}`;
 
+    // Previously posted comment will be deleted
+    const comments = await octokit.issues.listComments({
+        owner,
+        repo,
+        issue_number: prNumber,
+    });
+    const existing = comments.data.find(c => c.body && c.body.startsWith(':package: **Build Artifacts**'));
+    if (existing) {
+        await octokit.issues.deleteComment({
+            owner,
+            repo,
+            comment_id: existing.id,
+        });
+    }
+
     // Kommentar posten
     await octokit.issues.createComment({
         owner,


### PR DESCRIPTION
This pull request introduces a change to the `main` function in `src/index.ts` to ensure that previously posted comments about build artifacts are deleted before posting a new one. This prevents duplicate comments on the same pull request.

Changes to comment handling:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R49-R63): Added logic to fetch existing comments on the pull request, identify any comment starting with `:package: **Build Artifacts**`, and delete it before posting a new comment.