### PR TITLE
:bug: Fix artifact links in comment body to point to GitHub actions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30000,7 +30000,7 @@ function main() {
             return;
         }
         // Build the comment body with artifact links
-        const artifactLinks = artifacts.data.artifacts.map((a) => `- [${a.name}](${a.archive_download_url})`).join('\n');
+        const artifactLinks = artifacts.data.artifacts.map((a) => `- [${a.name}](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${a.id})`).join('\n');
         const body = `:package: **Build Artifacts**\n\n${artifactLinks}`;
         // Previously posted comment will be deleted
         const comments = yield octokit.issues.listComments({

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ async function main(): Promise<void> {
 
     // Build the comment body with artifact links
     const artifactLinks = artifacts.data.artifacts.map(
-        (a) => `- [${a.name}](${a.archive_download_url})`
+        (a) => `- [${a.name}](https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${a.id})`
     ).join('\n');
 
     const body = `:package: **Build Artifacts**\n\n${artifactLinks}`;


### PR DESCRIPTION
This pull request updates the artifact link generation in the `src/index.ts` file to provide more specific URLs for build artifacts.

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L44-R44): Updated the artifact links in the `main` function to include the repository owner, repository name, and run ID, creating more detailed and specific URLs for build artifacts.