### PR TITLE
🔧 Add renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended"],
+	"major": {
+		"automerge": false
+	},
+	"labels": ["📌 Dependencies"],
+	"commitMessagePrefix": "⬆️",
+	"commitMessageAction": "Upgrade",
+	"packageRules": [
+		{
+			"matchUpdateTypes": ["pin"],
+			"commitMessagePrefix": "📌",
+			"commitMessageAction": "Pin"
+		},
+		{
+			"matchUpdateTypes": ["rollback"],
+			"commitMessagePrefix": "⬇️",
+			"commitMessageAction": "Downgrade"
+		}
+	],
+	"dependencyDashboardTitle": "📌 Dependency Dashboard",
+	"dependencyDashboardLabels": ["📌 Dependencies"]
+}


### PR DESCRIPTION
This pull request adds a new configuration file for Renovate to manage dependency updates. The configuration specifies rules for automerging, labeling, and customizing commit messages based on the type of update.

Dependency management configuration:

* [`.github/renovate.json`](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3R1-R24): Introduced a Renovate configuration file with rules for handling major updates, pinning, and rollbacks. It includes custom labels, commit message prefixes, and actions for different update types, and sets up a dependency dashboard with specific labels.