### PR TITLE
🔧 Update renovate.json to use base config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,24 +1,6 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended"],
-	"major": {
-		"automerge": false
-	},
-	"labels": ["📌 Dependencies"],
-	"commitMessagePrefix": "⬆️",
-	"commitMessageAction": "Upgrade",
-	"packageRules": [
-		{
-			"matchUpdateTypes": ["pin"],
-			"commitMessagePrefix": "📌",
-			"commitMessageAction": "Pin"
-		},
-		{
-			"matchUpdateTypes": ["rollback"],
-			"commitMessagePrefix": "⬇️",
-			"commitMessageAction": "Downgrade"
-		}
-	],
-	"dependencyDashboardTitle": "📌 Dependency Dashboard",
-	"dependencyDashboardLabels": ["📌 Dependencies"]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>RubberDuckCrew/.github//configs/renovate/renovate-rubberduckcrew.json"
+    ]
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to use a shared preset from the RubberDuckCrew organization, replacing the previous custom rules and settings.

Renovate configuration update:

* The `.github/renovate.json` file now extends `github>RubberDuckCrew/.github//configs/renovate/renovate-rubberduckcrew.json`, removing all custom automerge, labeling, commit message, and dashboard rules in favor of the shared configuration.