### PR TITLE
👷 Add organization workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,9 @@
+name: Actionlint
+
+on:
+    pull_request:
+        paths: [.github/workflows/**]
+
+jobs:
+    run:
+        uses: RubberDuckCrew/.github/.github/workflows/action-actionlint.yml@main

--- a/.github/workflows/add-project.yml
+++ b/.github/workflows/add-project.yml
@@ -1,0 +1,10 @@
+name: Add to project
+
+on:
+    issues:
+        types: [opened]
+
+jobs:
+    run:
+        uses: RubberDuckCrew/.github/.github/workflows/action-add-project.yml@main
+        secrets: inherit

--- a/.github/workflows/close-actions.yml
+++ b/.github/workflows/close-actions.yml
@@ -1,0 +1,16 @@
+name: Close Actions
+
+on:
+    issues:
+        types: [closed]
+    pull_request:
+        types: [closed]
+
+jobs:
+    run:
+        uses: RubberDuckCrew/.github/.github/workflows/action-close-actions.yml@main
+        secrets: inherit
+        permissions:
+            issues: write
+            pull-requests: write
+            actions: write

--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -1,0 +1,12 @@
+name: Enforce conventions
+
+on:
+    pull_request:
+        types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+    run:
+        uses: RubberDuckCrew/.github/.github/workflows/action-conventions.yml@main
+        permissions:
+            issues: write
+            pull-requests: write

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,15 @@
+name: Sync labels
+
+on:
+    schedule:
+        - cron: "0 3 * * 0"
+    push:
+        branches: [main]
+        paths: [.github/workflows/sync-labels.yml]
+    workflow_dispatch:
+
+jobs:
+    run:
+        uses: RubberDuckCrew/.github/.github/workflows/action-sync-labels.yml@main
+        permissions:
+            issues: write


### PR DESCRIPTION
This pull request adds several new GitHub Actions workflow files to automate and enforce repository processes. The workflows cover linting, project management, conventions enforcement, label synchronization, and closing actions. These changes help standardize and streamline repository management by leveraging reusable workflows from the `RubberDuckCrew/.github` repository.

**Repository automation and management:**

* Added `.github/workflows/actionlint.yml` to run Actionlint on workflow file changes, improving workflow file quality.
* Added `.github/workflows/add-project.yml` to automatically add new issues to a project board when opened.
* Added `.github/workflows/close-actions.yml` to automate closing actions for issues and pull requests, with appropriate permissions.
* Added `.github/workflows/conventions.yml` to enforce repository conventions on pull requests, ensuring consistency.
* Added `.github/workflows/sync-labels.yml` to regularly synchronize issue labels via scheduled, push, and manual triggers.