### PR TITLE
👷 Fix build needs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -78,7 +78,7 @@ jobs:
         name: Commit Action Build
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/main'
-        needs: test
+        needs: build
 
         permissions:
             contents: write


### PR DESCRIPTION
This pull request makes a small update to the workflow configuration by changing the dependency for the "Commit Action Build" job. The job now depends on the `build` job instead of the `test` job in the `.github/workflows/build-test.yml` file.