### PR TITLE
👷 Add token to checkout step in build workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -100,7 +100,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
               with:
-                  token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+                  token: ${{ steps.app-token.outputs.token || github.token }}
 
             - name: Download action artifact
               uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6


### PR DESCRIPTION
This pull request updates the workflow configuration in `.github/workflows/build-test.yml` to improve how authentication tokens are handled during repository checkout and artifact commits. The main change ensures that the correct token is used for checking out the repository, while removing the token specification from the commit step.

Workflow authentication updates:

* The `actions/checkout` step now explicitly uses the token from either `steps.app-token.outputs.token` or `secrets.GITHUB_TOKEN`, ensuring proper authentication for repository access.
* The `stefanzweifel/git-auto-commit-action` step no longer specifies the token parameter, relying on default authentication behavior for committing the `dist` directory.