### PR TITLE
👷 Add user details for auto-commit action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -113,3 +113,5 @@ jobs:
               with:
                   commit_message: "📦 Update action build [skip ci]"
                   file_pattern: "dist/**"
+                  commit_user_name: "RubberDuckCrew Bot"
+                  commit_user_email: "231319061+rubberduckcrew-bot[bot]@users.noreply.github.com"


### PR DESCRIPTION
This pull request introduces a small update to the workflow configuration for automated builds. The change ensures that commits made by the automation use a dedicated bot identity for clearer attribution.

* Workflow configuration update:
  * [`.github/workflows/build-test.yml`](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32R116-R117): Set `commit_user_name` and `commit_user_email` to identify commits as originating from the "RubberDuckCrew Bot".