### PR TITLE
👷 Use app token to commit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -127,4 +127,5 @@ jobs:
                   files: |
                       dist/index.js
                       dist/licenses.txt
+                  github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
                   fail_on_self_push: false


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The change ensures that the workflow uses an appropriate GitHub token, preferring the app token if available, otherwise falling back to the default secret.

* Updated the `github_token` parameter in `.github/workflows/build-test.yml` to use the app token if present, or the default `GITHUB_TOKEN` secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow with improved authentication handling for automated commits of generated artifacts, ensuring secure credential propagation during deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->