### PR TITLE
📝 Add badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Artifact2PR
 
+[![Release](https://img.shields.io/github/v/release/RubberDuckCrew/artifact2pr?style=flat-square&color=blue)](https://github.com/RubberDuckCrew/artifact2pr/releases)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/RubberDuckCrew/artifact2pr/build-test.yml?style=flat-square&label=Build%20and%20Test&color=lime)](https://github.com/RubberDuckCrew/artifact2pr/actions/workflows/build-test.yml)
+[![Last Commit](https://img.shields.io/github/last-commit/RubberDuckCrew/artifact2pr?style=flat-square&color=orange)](https://github.com/RubberDuckCrew/artifact2pr/commits/main)
+[![License: MIT](https://img.shields.io/github/license/RubberDuckCrew/artifact2pr?style=flat-square&color=yellow)](LICENSE)
+
 A GitHub Action to automatically post links to build artifacts as a comment on pull requests.
 
 ## Features


### PR DESCRIPTION
This pull request adds several status badges to the top of the `README.md` file to improve project visibility and provide quick access to important project metrics.

Enhancements to project documentation:

* Added badges for release version, build and test status, last commit date, and license to the top of the `README.md` for better visibility and easier access to key project information.