### PR TITLE
👷 Update files to commit on build and release

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -124,8 +124,6 @@ jobs:
               uses: suzuki-shunsuke/commit-action@f28421acc277a6d6a9c1f94ea449076ad77dba67 # v0.1.0
               with:
                   commit_message: "📦 Update action build [skip ci]"
-                  files: |
-                      dist/index.js
-                      dist/licenses.txt
+                  files: dist/
                   github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
                   fail_on_self_push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
               uses: suzuki-shunsuke/commit-action@f28421acc277a6d6a9c1f94ea449076ad77dba67 # v0.1.0
               with:
                   commit_message: "🔖 Release v${{ github.event.inputs.version }} [skip ci]"
+                  files: |
+                      dist/
+                      package.json
+                      package-lock.json
                   github_token: ${{ steps.app-token.outputs.token || github.token }}
                   fail_on_self_push: false
 


### PR DESCRIPTION
This pull request updates the file lists specified for committing build and release artifacts in the GitHub Actions workflows. The main changes ensure that the entire `dist/` directory and relevant package files are included in commits during build and release automation.

**Workflow file updates:**

* Build workflow:
  - Changed the commit action to include the entire `dist/` directory instead of just individual files (`dist/index.js` and `dist/licenses.txt`) when committing build artifacts.

* Release workflow:
  - Updated the commit action to include the `dist/` directory as well as `package.json` and `package-lock.json` when committing release artifacts.